### PR TITLE
Add WAM namespace to types

### DIFF
--- a/src/c/dx7.cc
+++ b/src/c/dx7.cc
@@ -1,6 +1,6 @@
 //
 //  dx7.cc
-//  
+//
 //
 //  Created by Jari Kleimola on 04/04/15.
 //
@@ -21,7 +21,7 @@ const char* DX7::init(uint32_t bufsize, uint32_t sr, void* desc)
 	Sin::init();
 	Lfo::init(sr);
 	PitchEnv::init(sr);
-	
+
 	bufsize_ = bufsize;
 	outbuf16_ = new int16_t[bufsize];
 	synth_unit_ = new SynthUnit(&ring_buffer_);
@@ -41,13 +41,13 @@ void DX7::resize(uint32_t bufsize)
 	outbuf16_ = new int16_t[bufsize_];
 }
 
-void DX7::onMidi(byte status, byte data1, byte data2)
+void DX7::onMidi(WAM::byte status, WAM::byte data1, WAM::byte data2)
 {
 	uint8_t msg[3] = { status, data1, data2 };
 	ring_buffer_.Write(msg, 3);
 }
 
-void DX7::onSysex(byte* msg, uint32_t size)
+void DX7::onSysex(WAM::byte* msg, uint32_t size)
 {
 	if (size == 4104)
 		ring_buffer_.Write(msg, 4104);
@@ -55,7 +55,7 @@ void DX7::onSysex(byte* msg, uint32_t size)
 
 void DX7::onPatch(void* patch, uint32_t size)
 {
-	synth_unit_->onPatch((byte*)patch, size);
+	synth_unit_->onPatch((WAM::byte*)patch, size);
 }
 
 void DX7::onParam(uint32_t idparam, double value)
@@ -63,11 +63,11 @@ void DX7::onParam(uint32_t idparam, double value)
 	synth_unit_->onParam(idparam, (char)value);
 }
 
-void DX7::onProcess(AudioBus* audio, void* data)
+void DX7::onProcess(WAM::AudioBus* audio, void* data)
 {
 	// mono 16-bit signed ints
 	synth_unit_->GetSamples(bufsize_, outbuf16_);
-	
+
 	static const float scaler = 0.00003051757813;
 	float* outbuf = audio->outputs[0];
 	for (uint32_t n=0; n<bufsize_; n++)

--- a/src/c/dx7.h
+++ b/src/c/dx7.h
@@ -1,6 +1,6 @@
 //
 //  dx7.h
-//  
+//
 //
 //  Created by Jari Kleimola on 04/04/15.
 //
@@ -14,15 +14,15 @@
 #include "msfa/synth_unit.h"
 #include "msfa/ringbuffer.h"
 
-class DX7 : public Processor
+class DX7 : public WAM::Processor
 {
 public:
 	virtual const char* init(uint32_t bufsize, uint32_t sr, void* desc);
 	virtual void terminate();
 	virtual void resize(uint32_t bufsize);
-	virtual void onProcess(AudioBus* audio, void* data);
-	virtual void onMidi(byte status, byte data1, byte data2);
-	virtual void onSysex(byte* msg, uint32_t size);
+	virtual void onProcess(WAM::AudioBus* audio, void* data);
+	virtual void onMidi(WAM::byte status, WAM::byte data1, WAM::byte data2);
+	virtual void onSysex(WAM::byte* msg, uint32_t size);
 	virtual void onPatch(void* patch, uint32_t size);
 	virtual void onParam(uint32_t idparam, double value);
 private:


### PR DESCRIPTION
I am facing some errors (13 in totals) caused by the missing namespace `WAM` for some types. 

Example:

```sh
In file included from ../src/c/dx7.cc:9:
../src/c/dx7.h:17:20: error: unknown class name 'Processor'; did you mean 'WAM::Processor'?
class DX7 : public Processor
                   ^~~~~~~~~
                   WAM::Processor
../src/wamsdk/processor.h:23:7: note: 'WAM::Processor' declared here
class Processor
      ^
```

I am using:

```sh
$ emcc -v
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 1.37.35
clang version 5.0.0  (emscripten 1.37.35 : 1.37.35)
Target: x86_64-apple-darwin17.4.0
Thread model: posix
InstalledDir: /Users/piou/Desktop/emsdk-portable/clang/e1.37.35_64bit
INFO:root:(Emscripten: Running sanity checks)
```

**I am a JS developer so I have no idea of what I am doing** 😅 but it seems to compile correctly now.

Super interesting repo 💕 I am learning a lot by diving in! 